### PR TITLE
Extra gui buttons for common usecases.

### DIFF
--- a/views/gallery.hbs
+++ b/views/gallery.hbs
@@ -31,8 +31,9 @@
 								</div>
 							</div>
 							<div class="extra content">
-								<span onclick="startRename('{{nonce}}','{{name}}')" class="left floated mini ui button"><i class="edit icon"></i>Rename</span>
-								<span onclick="startDelete('{{nonce}}','{{name}}')" class="right floated mini negative ui button"><i class="eraser icon"></i>Delete</span>
+								<span onclick="copyLinkToClipboard(this)" class="ui mini compact primary icon button"><i class="copy outline icon"></i></span>
+								<span onclick="startRename('{{nonce}}','{{name}}')" class=" ui mini compact button"><i class="edit icon"></i>Rename</span>
+								<span onclick="startDelete('{{nonce}}','{{name}}')" class="right floated ui mini compact negative button"><i class="eraser icon"></i>Delete</span>
 							</div>
 						</div>
 					{{/each}}

--- a/views/gallery.hbs
+++ b/views/gallery.hbs
@@ -31,9 +31,14 @@
 								</div>
 							</div>
 							<div class="extra content">
-								<span onclick="copyLinkToClipboard(this)" class="ui mini compact primary icon button"><i class="copy outline icon"></i></span>
-								<span onclick="startRename('{{nonce}}','{{name}}')" class=" ui mini compact button"><i class="edit icon"></i>Rename</span>
-								<span onclick="startDelete('{{nonce}}','{{name}}')" class="right floated ui mini compact negative button"><i class="eraser icon"></i>Delete</span>
+								<span onclick="copyGalerryToClipboard(this)" class="ui mini primary icon button"><i class="copy outline icon"></i></span>
+								<div class="ui right floated mini icon button clickpopupactivator" data-position="top center"><i class="icon settings"></i></div>
+								<div class="ui flowing popup transition hidden">
+									<div class="ui mini labeled icon buttons">
+										<div onclick="startRename('{{nonce}}','{{name}}')" class="ui button"><i class="edit icon"></i>Rename</div>
+										<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui negative button"><i class="eraser icon"></i>Delete</div>
+									</div>
+								</div>
 							</div>
 						</div>
 					{{/each}}

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -30,6 +30,16 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qs/6.5.1/qs.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery_lazyload/1.9.7/jquery.lazyload.min.js"></script>
 <script>
+	function copyToClipboard(text) {
+		let tempImput = $("<input>");
+		$("body").append(tempImput);
+		tempImput.val(text).select();
+		document.execCommand("copy");
+		tempImput.remove();
+	}
+	function copyLinkToClipboard(element) {
+		copyToClipboard($(element).parent().parent().children("a")[0].href);
+	}
 	function startRename(nonce, name) {
 		let newName = prompt("Please proivide new filename", name);
 		if (newName) {

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -37,7 +37,10 @@
 		document.execCommand("copy");
 		tempImput.remove();
 	}
-	function copyLinkToClipboard(element) {
+	function copyListToClipboard(element) {
+		copyToClipboard($(element).parent().parent().parent().children("td").children("a")[0].href);
+	}
+	function copyGalerryToClipboard(element) {
 		copyToClipboard($(element).parent().parent().children("a")[0].href);
 	}
 	function startRename(nonce, name) {
@@ -128,6 +131,11 @@
 			e.preventDefault();
 			alert($(this)[0].href); /* This realy should be something nicer then alert. Dunno what ;p */
 		});
+		
+		$(".clickpopupactivator").popup({
+			inline: true,
+			on: 'click'
+		 });
 
 		if ( $(".ui.file.input").length ) {
 			

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -38,7 +38,7 @@
 		tempImput.remove();
 	}
 	function copyListToClipboard(element) {
-		copyToClipboard($(element).parent().parent().parent().children("td").children("a")[0].href);
+		copyToClipboard($(element).parent().parent().children("td").children("a")[0].href);
 	}
 	function copyGalerryToClipboard(element) {
 		copyToClipboard($(element).parent().parent().children("a")[0].href);

--- a/views/links.hbs
+++ b/views/links.hbs
@@ -21,7 +21,7 @@
 					<tbody>
 						{{#each files}}
 							<tr>
-								<td><a href="{{@root.pathname}}l/{{name}}" class="alertable">{{name}} -> {{c}}</a></td>
+								<td><a href="{{@root.pathname}}l/{{name}}" class="alertable">{{name}} -> {{c}}</a><a href="{{@root.pathname}}l/{{name}}" class="right floated"><i class="external icon"></i></a></td>
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">

--- a/views/links.hbs
+++ b/views/links.hbs
@@ -23,16 +23,21 @@
 							<tr>
 								<td>
 									<a href="{{@root.pathname}}l/{{name}}" class="alertable">{{name}} -> {{c}}</a>
-									<div class="ui right floated mini icon buttons">
-										<div onclick="copyLinkToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
-										<a href="{{@root.pathname}}l/{{name}}" class="ui secondary button"><i class="external icon"></i></a>
-									</div>
 								</td>
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">
-									<div onclick="startRename('{{nonce}}','{{name}}')" class="ui mini button"><i class="edit icon"></i>Rename</div>
-									<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui mini negative button"><i class="eraser icon"></i>Delete</div>
+									<div class="ui mini icon buttons">
+										<div onclick="copyListToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
+										<a href="{{@root.pathname}}l/{{name}}" class="ui button"><i class="external icon"></i></a>
+										<div class="ui button clickpopupactivator" data-position="left center"><i class="icon settings"></i></div>
+										<div class="ui flowing popup transition hidden">
+											<div class="ui mini labeled icon buttons">
+												<div onclick="startRename('{{nonce}}','{{name}}')" class="ui button"><i class="edit icon"></i>Rename</div>
+												<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui negative button"><i class="eraser icon"></i>Delete</div>
+											</div>
+										</div>
+									</div>
 								</td>
 							</tr>
 						{{/each}}

--- a/views/links.hbs
+++ b/views/links.hbs
@@ -27,15 +27,13 @@
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">
-									<div class="ui mini icon buttons">
-										<div onclick="copyListToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
-										<a href="{{@root.pathname}}l/{{name}}" class="ui button"><i class="external icon"></i></a>
-										<div class="ui button clickpopupactivator" data-position="left center"><i class="icon settings"></i></div>
-										<div class="ui flowing popup transition hidden">
-											<div class="ui mini labeled icon buttons">
-												<div onclick="startRename('{{nonce}}','{{name}}')" class="ui button"><i class="edit icon"></i>Rename</div>
-												<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui negative button"><i class="eraser icon"></i>Delete</div>
-											</div>
+									<div onclick="copyListToClipboard(this)" class="ui mini icon primary button"><i class="copy outline icon"></i></div>
+									<a href="{{@root.pathname}}l/{{name}}" class="ui mini icon button"><i class="external icon"></i></a>
+									<div class="ui mini icon button clickpopupactivator" data-position="left center"><i class="icon settings"></i></div>
+									<div class="ui flowing popup transition hidden">
+										<div class="ui mini labeled icon buttons">
+											<div onclick="startRename('{{nonce}}','{{name}}')" class="ui button"><i class="edit icon"></i>Rename</div>
+											<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui negative button"><i class="eraser icon"></i>Delete</div>
 										</div>
 									</div>
 								</td>

--- a/views/links.hbs
+++ b/views/links.hbs
@@ -21,7 +21,13 @@
 					<tbody>
 						{{#each files}}
 							<tr>
-								<td><a href="{{@root.pathname}}l/{{name}}" class="alertable">{{name}} -> {{c}}</a><a href="{{@root.pathname}}l/{{name}}" class="right floated"><i class="external icon"></i></a></td>
+								<td>
+									<a href="{{@root.pathname}}l/{{name}}" class="alertable">{{name}} -> {{c}}</a>
+									<div class="ui right floated mini icon buttons">
+										<div onclick="copyLinkToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
+										<a href="{{@root.pathname}}l/{{name}}" class="ui secondary button"><i class="external icon"></i></a>
+									</div>
+								</td>
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">

--- a/views/list.hbs
+++ b/views/list.hbs
@@ -21,7 +21,7 @@
 					<tbody>
 						{{#each files}}
 							<tr>
-								<td><a href="{{@root.pathname}}{{name}}">{{name}}</a></td>
+								<td><a href="{{@root.pathname}}{{name}}">{{name}}</a><a href="{{@root.pathname}}paste/{{name}}" class="right floated"><i class="code icon"></i></a></td>
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">

--- a/views/list.hbs
+++ b/views/list.hbs
@@ -27,15 +27,13 @@
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">
-									<div class="ui mini icon buttons">
-										<div onclick="copyListToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
-										<a href="{{@root.pathname}}paste/{{name}}" class="ui button"><i class="code icon"></i></a>
-										<div class="ui button clickpopupactivator" data-position="left center"><i class="icon settings"></i></div>
-										<div class="ui flowing popup transition hidden">
-											<div class="ui mini labeled icon buttons">
-												<div onclick="startRename('{{nonce}}','{{name}}')" class="ui button"><i class="edit icon"></i>Rename</div>
-												<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui negative button"><i class="eraser icon"></i>Delete</div>
-											</div>
+									<div onclick="copyListToClipboard(this)" class="ui mini icon primary button"><i class="copy outline icon"></i></div>
+									<a href="{{@root.pathname}}paste/{{name}}" class="ui mini icon button"><i class="code icon"></i></a>
+									<div class="ui mini icon button clickpopupactivator" data-position="left center"><i class="icon settings"></i></div>
+									<div class="ui flowing popup transition hidden">
+										<div class="ui mini labeled icon buttons">
+											<div onclick="startRename('{{nonce}}','{{name}}')" class="ui button"><i class="edit icon"></i>Rename</div>
+											<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui negative button"><i class="eraser icon"></i>Delete</div>
 										</div>
 									</div>
 								</td>

--- a/views/list.hbs
+++ b/views/list.hbs
@@ -21,7 +21,13 @@
 					<tbody>
 						{{#each files}}
 							<tr>
-								<td><a href="{{@root.pathname}}{{name}}">{{name}}</a><a href="{{@root.pathname}}paste/{{name}}" class="right floated"><i class="code icon"></i></a></td>
+								<td>
+									<a href="{{@root.pathname}}{{name}}">{{name}}</a>
+									<div class="ui right floated mini icon buttons">
+										<div onclick="copyLinkToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
+										<a href="{{@root.pathname}}paste/{{name}}" class="ui secondary button"><i class="code icon"></i></a>
+									</div>
+								</td>
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">

--- a/views/list.hbs
+++ b/views/list.hbs
@@ -23,16 +23,21 @@
 							<tr>
 								<td>
 									<a href="{{@root.pathname}}{{name}}">{{name}}</a>
-									<div class="ui right floated mini icon buttons">
-										<div onclick="copyLinkToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
-										<a href="{{@root.pathname}}paste/{{name}}" class="ui secondary button"><i class="code icon"></i></a>
-									</div>
 								</td>
 								<td class="collapsing">{{dateformat mtime}}</td>
 								<td class="collapsing">{{fileSize size}}</td>
 								<td class="right aligned collapsing">
-									<div onclick="startRename('{{nonce}}','{{name}}')" class="ui mini button"><i class="edit icon"></i>Rename</div>
-									<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui mini negative button"><i class="eraser icon"></i>Delete</div>
+									<div class="ui mini icon buttons">
+										<div onclick="copyListToClipboard(this)" class="ui primary button"><i class="copy outline icon"></i></div>
+										<a href="{{@root.pathname}}paste/{{name}}" class="ui button"><i class="code icon"></i></a>
+										<div class="ui button clickpopupactivator" data-position="left center"><i class="icon settings"></i></div>
+										<div class="ui flowing popup transition hidden">
+											<div class="ui mini labeled icon buttons">
+												<div onclick="startRename('{{nonce}}','{{name}}')" class="ui button"><i class="edit icon"></i>Rename</div>
+												<div onclick="startDelete('{{nonce}}','{{name}}')" class="ui negative button"><i class="eraser icon"></i>Delete</div>
+											</div>
+										</div>
+									</div>
 								</td>
 							</tr>
 						{{/each}}


### PR DESCRIPTION
Adds Copy To Clipboard buttons in valid spots + Adds buttons that link to text/code viewer ( on list page ) or target page ( on links page ).
Kinda makes sense to have those common functions simplified down to button click.

![obraz](https://user-images.githubusercontent.com/5893536/40285889-8226f6c8-5ca1-11e8-97bb-5a26eeb54634.png)
![obraz](https://user-images.githubusercontent.com/5893536/40285897-8b80ffc0-5ca1-11e8-995d-b4b8ce342573.png)
![obraz](https://user-images.githubusercontent.com/5893536/40285900-929f1d14-5ca1-11e8-99f2-ae05e9476fa0.png)
