### PR TITLE
Add Page with ShareX configuration generation + cleanup clientside javascripts / implement section helper.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,18 @@ if (!fs.existsSync(`${config.imagePath}/.deleted`)){
     fs.mkdirSync(`${config.imagePath}/.deleted`);
 }
 
-app.engine(".hbs", handlebars({ defaultLayout: "main", extname: ".hbs", helpers: _.merge(helpers, { "dateformat" : dateformat }) }));
+app.engine(".hbs", handlebars({
+	defaultLayout: "main",
+	extname: ".hbs",
+	helpers: _.merge(helpers, {
+		"dateformat" : dateformat,
+		section: function(name, options){
+			if(!this._sections) this._sections = {};
+			this._sections[name] = options.fn(this);
+			return null;
+		}
+	})
+}));
 app.set("view engine", ".hbs");
 app.use(session({
 	secret: config.sessionSecret,

--- a/index.js
+++ b/index.js
@@ -485,6 +485,14 @@ router.get("/gallery/:page?", auth, (req, res) => fileListing("*.<(jpeg|jpg|png|
 router.get("/list/:page?", auth, (req, res) => fileListing("*", "list", pathname+"list", req, res));
 router.get("/links/:page?", auth, (req, res) => fileListing("<^[^.]+$>", "links", pathname+"links", req, res));
 
+router.get("/misc", auth, (req, res) => {
+	res.render("misc", {
+		config: _.omit(config, ["password", "sessionSecret"]),
+		pageTemplate: "misc",
+		pathname
+	});
+});
+
 console.log(`Listening on ${config.listen} under path ${pathname}`);
 
 app.use(pathname, router);

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -119,11 +119,13 @@
 		$.event.special.swipe.durationThreshold = 100;
 
 		$( "div.ui.grid" ).on( "swiperight", function(e){
-			if ($("a.ui.icon.button").not(".right").not(".disabled").length) { $("a.ui.icon.button").not(".right").not(".disabled")[0].click() }
+			console.log("swiperight");
+			if ($("a.ui.icon.button.pageLeft").not(".disabled").length) { $("a.ui.icon.button.pageLeft").not(".right").not(".disabled")[0].click() }
 			else if ($("a.ui.button.active").prev().length) { $("a.ui.button.active").prev()[0].click() }
 		});
 		$( "div.ui.grid" ).on( "swipeleft", function(){
-			if ($("a.ui.right.icon.button").not(".disabled").length) { $("a.ui.right.icon.button").not(".disabled")[0].click() }
+			console.log("swipeleft");
+			if ($("a.ui.icon.button.pageRight").not(".disabled").length) { $("a.ui.icon.button.pageRight").not(".disabled")[0].click() }
 			else if ($("a.ui.button.active").next().length) { $("a.ui.button.active").next()[0].click() }
 		});
 		
@@ -209,7 +211,7 @@
 
 			};
 
-			$(".ui.fluid.button").on("click", function(e) {
+			$("#SubmitButton").on("click", function(e) {
 				e.preventDefault();
 				e.stopPropagation();
 				SubmitData( $("input:file", ".ui.file.input")[0].files.item(0) );

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -30,19 +30,25 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qs/6.5.1/qs.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery_lazyload/1.9.7/jquery.lazyload.min.js"></script>
 <script>
+
+	var urlParams = typeof URLSearchParams === "function" ? new URLSearchParams(location.search) : { get: function() { return undefined; } }
+
 	function copyToClipboard(text) {
 		let tempImput = $("<input>");
 		$("body").append(tempImput);
 		tempImput.val(text).select();
 		document.execCommand("copy");
 		tempImput.remove();
-	}
+	};
+
 	function copyListToClipboard(element) {
 		copyToClipboard($(element).parent().parent().children("td").children("a")[0].href);
-	}
+	};
+
 	function copyGalerryToClipboard(element) {
 		copyToClipboard($(element).parent().parent().children("a")[0].href);
-	}
+	};
+
 	function startRename(nonce, name) {
 		let newName = prompt("Please proivide new filename", name);
 		if (newName) {
@@ -53,69 +59,33 @@
 			.submit();
 		};
 	};
+
 	function startDelete(nonce, name) {
 		if (confirm(`Please confirm you want to delete the ${name} file.`)) {
-			$(`<form action='{{pathname}}delete/${nonce}' method="POST"/>`)
+			$(`<form action="{{pathname}}delete/${nonce}" method="POST"/>`)
 			.appendTo($(document.body))
 			.submit();
 		};
 	};
-	$(function() {
 
-		var urlParams = typeof URLSearchParams === "function" ? new URLSearchParams(location.search) : { get: function() { return undefined; } }
+	$(function() {
 
 		$("img.lazy").lazyload({
 			effect: "fadeIn"
 		});
-
-		$(".ui.file.input").find("input:text, .ui.button").on("click", function(e) {
-			$(e.target).parent().find("input:file").click();
-		});
-
-		$("input:file", ".ui.file.input").on("change", function(e) {
-			var file = $(e.target);
-			var name = "";
-
-			for (var i=0; i<e.target.files.length; i++) {
-				name += e.target.files[i].name + ", ";
-			}
-
-			name = name.replace(/,\s*$/, "");
-
-			$("input:text", file.parent()).val(name);
-		});
-
-		$("#rangestart").calendar({
-			type: "date",
-			endCalendar: $("#rangeend")
-		}).calendar("set date",urlParams.get('start'));
-
-		$("#rangeend").calendar({
-			type: "date",
-			startCalendar: $("#rangestart")
-		}).calendar("set date",urlParams.get('end'));
-
+		
 		$(".ui.accordion").accordion();
 
-		$("#filter-search").val(urlParams.get('search'));
-		$("#filter-search").keyup(function(event) {
-			if (event.keyCode === 13) {
-				$("#filter-submit").click();
-			}
-		});
-		
-		$("#filter-submit").click(function() {
-			const q = Qs.parse(location.search.replace(/^\?/, ""));
-			if ($("#rangestart").calendar("get date")) q.start = $("#rangestart").calendar("get date").toString();
-			if ($("#rangeend").calendar("get date")) q.end = $("#rangeend").calendar("get date").toString();
-			q.search = $("#filter-search").val();
-			location.search = Qs.stringify(q);
+		$(".clickpopupactivator").popup({
+			inline: true,
+			on: 'click'
 		});
 
-		$("#filter-clear").click(function() {
-			location.search = "";
+		$(".alertable").on( "click", function(e) {
+			e.preventDefault();
+			alert($(this)[0].href); /* This realy should be something nicer then alert. Dunno what ;p */
 		});
-		
+
 		$.event.special.swipe.durationThreshold = 100;
 
 		$( "div.ui.grid" ).on( "swiperight", function(e){
@@ -128,140 +98,18 @@
 			if ($("a.ui.icon.button.pageRight").not(".disabled").length) { $("a.ui.icon.button.pageRight").not(".disabled")[0].click() }
 			else if ($("a.ui.button.active").next().length) { $("a.ui.button.active").next()[0].click() }
 		});
-		
-		$(".alertable").on( "click", function(e) {
+{{#eq pageTemplate "upload"}}{{else}}
+		$("div.ui.fluid.four.basic.buttons").children().last().on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
 			e.preventDefault();
-			alert($(this)[0].href); /* This realy should be something nicer then alert. Dunno what ;p */
-		});
-		
-		$(".clickpopupactivator").popup({
-			inline: true,
-			on: 'click'
-		 });
-
-		if ( $(".ui.file.input").length ) {
-			
-			$('.ui.dropdown').dropdown().dropdown({
-				onChange: function(value, text, selectedItem) {
-					let name = $("#name").val();
-					$(".ui.basic.form")[0].reset();
-					$("#name").val(name);
-					if (value == "Link") {
-						$('#Filefield').hide();
-						$('#URLfield').show();
-					}
-					else {
-						$('#Filefield').show();
-						$('#URLfield').hide();
-					};
-				}
-			});
-			
-			function errorMessage(err) {
-				$("body").html('<div class="ui middle aligned center aligned grid"><div class="column"><div class="ui centered green card"><div class="content"><h1 class="header" style="color: #DB2828 !important; font-size: 175%">Error</h1></div><p class="ui content text" id="error" style="font-size: 120%"></p><p class="ui content text" style="font-size: 120%"><button class="ui primary button" onClick="window.location.reload(true)" type="button">Go Back</button></p></div></div></div>');
-				$("#error").text(err);
-			}
-			
-			function SubmitData(file) {
-				if (file == null && $('#mode').val() != "Link") return errorMessage("No file specified.");
-				$(".ui.fluid.button").addClass('loading').addClass('disabled');
-				var progress = $('#progress').show().progress().progress("set percent",0);
-				var formData = new FormData();
-				formData.append("name",$("#name").val());
-				var urlQuery = "{{pathname}}upload";
-				if ($('#mode').val() != "Link") {
-					if ($('#mode').val() == "Paste") {
-						urlQuery = "{{pathname}}upload?"+$.param({ paste : 'true'});
-					}
-					formData.append("file",file);
-					
-				}
-				else {
-					formData.append("link",$('#URL').val());
-				};
-				$.ajax({
-				url: urlQuery,
-				data: formData,
-				processData: false,
-				contentType: false,
-				type: 'POST',
-				xhr: function(){
-					var xhr = new window.XMLHttpRequest();
-					function HandlePrecent(evt) {if (evt.lengthComputable) { progress.progress("set percent",evt.loaded / evt.total * 100); } }
-					xhr.upload.addEventListener("progress", HandlePrecent, false);
-					xhr.addEventListener("progress", HandlePrecent, false);
-					return xhr;
-				},
-				success: function(result){
-					if (result.ok){
-						if ($('#mode').val() != "Link") {
-							window.location.href = result.url ;
-						}
-						else {
-							$("body").html('<div class="ui middle aligned center aligned grid"><div class="column"><div class="ui centered green card"><div class="content"><h1 class="header" style="color: #229A33 !important; font-size: 175%">Success</h1></div><p class="ui content text" id="success" style="font-size: 120%"></p><p class="ui content text" style="font-size: 120%"><button  class="ui primary button" onClick="window.location.reload(true)" type="button">Go Back</button></p></div></div></div>');
-							$("#success").text(result.url);
-						}
-					}
-					else { errorMessage(result.error)}
-				},
-				error: function(xhr, textStatus, errorThrown){
-					errorMessage("Error Uploading: " + errorThrown);
-				}
-				});
-
-			};
-
-			$("#SubmitButton").on("click", function(e) {
-				e.preventDefault();
-				e.stopPropagation();
-				SubmitData( $("input:file", ".ui.file.input")[0].files.item(0) );
-			});
-
-			$( document ).on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
-				e.preventDefault();
-				e.stopPropagation();
-			})
-			.on('dragover dragenter', function() {
-				if ($('#mode').val() == "Link") {
-					$('.ui.dropdown').dropdown("set selected","File");
-				}
-				$(".ui.fluid.button").removeClass('primary').addClass('secondary').html("Drop to upload");
-				$(".ui.basic.form.segment.left.aligned").children(":first").addClass('disabled');
-				$('#Filefield').addClass('disabled');
-			})
-			.on('dragleave dragend', function() {
-				$(".ui.fluid.button").removeClass('secondary').addClass('primary').html("Submit");
-				$(".ui.basic.form.segment.left.aligned").children(":first").removeClass('disabled');
-				$('#Filefield').removeClass('disabled');
-			})
-			.on('drop', function(e) {
-				$(".ui.fluid.button").removeClass('secondary').addClass('primary').html("Submit");
-				$("input:file", ".ui.file.input").parent().children(":first").val("Droped File");
-				SubmitData(e.originalEvent.dataTransfer.files.item(0));
-			})
-			.on("paste", function(e){
-				var pastedData = e.originalEvent.clipboardData.items[0];
-				if ($('#mode').val() != "Link" && pastedData.kind === 'file') {
-					e.preventDefault();
-					e.stopPropagation();
-					$(".ui.basic.form.segment.left.aligned").children(":first").addClass('disabled');
-					$("input:file", ".ui.file.input").parent().children(":first").val("Pasted File");
-					SubmitData(pastedData.getAsFile());
-				}
-				
-			});
-		}
-		else {
-			$("div.ui.fluid.four.basic.buttons").children().last().on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
-				e.preventDefault();
-				e.stopPropagation();
-			})
-			.on('dragenter', function() {
-				$("div.ui.fluid.four.basic.buttons").children().last()[0].click();
-			})
-		};
-
+			e.stopPropagation();
+		})
+		.on('dragenter', function() {
+			$("div.ui.fluid.four.basic.buttons").children().last()[0].click();
+		})
+{{/eq}}
 	});
 </script>
+{{{_sections.script}}}
+{{{_sections.filters}}}
 </body>
 </html>

--- a/views/misc.hbs
+++ b/views/misc.hbs
@@ -1,0 +1,77 @@
+<div class="ui grid">
+	<div class="column" style="margin: 2rem; padding-bottom: 2rem;">
+		<div class="ui centered fluid card">
+			<div class="ui content center aligned">
+				{{> navigation }}
+			</div>
+			<div class="ui content center aligned">
+				<div class="ui input">
+					<input id="pas" placeholder="Password here" type="text">
+					<div class="ui positive button" onclick="$('textarea').each( function(){$(this).val($(this).text().replace('SHITTYPASSWORDHERE',$('#pas').val()));})">Set</div>
+					<div class="ui negative button" onclick="$('textarea').each(function(){$(this).val($(this).text());$('#pas').val('');})">Reset</div>
+				</div>
+			</div>
+			<div class="ui content">
+				<div class="ui link three doubling cards">
+					<div class="card">
+						<div class="content">
+							<div class="header">ShareX Image&File Uploader</div>
+						</div>
+<textarea class="image" readonly style="resize: none; border: none; font-family: monospace" rows=10>{
+  "Name": "{{config.name}} Image&File",
+  "DestinationType": "ImageUploader, FileUploader",
+  "RequestURL": "{{config.url}}upload",
+  "FileFormName": "file",
+  "Arguments": {
+    "password": "SHITTYPASSWORDHERE"
+  },
+  "URL": "$json:.url$",
+  "DeletionURL": "$json:.deleteUrl$"
+}</textarea>
+						<div class="extra content">
+							<div class="ui mini icon primary button" onclick="copyToClipboard($(this).parent().parent().children('textarea').val())"><i class="copy outline icon"></i></div>
+						</div>
+					</div>
+					<div class="card">
+						<div class="content">
+							<div class="header">ShareX Text Uploader</div>
+						</div>
+<textarea class="image" readonly style="resize: none; border: none; font-family: monospace" rows=10>{
+  "Name": "{{config.name}} Text",
+  "DestinationType": "TextUploader",
+  "RequestURL": "{{config.url}}upload?paste=true",
+  "FileFormName": "file",
+  "Arguments": {
+    "password": "SHITTYPASSWORDHERE"
+  },
+  "URL": "$json:.url$",
+  "DeletionURL": "$json:.deleteUrl$"
+}</textarea>
+						<div class="extra content">
+							<div class="ui mini icon primary button" onclick="copyToClipboard($(this).prev().val())"><i class="copy outline icon"></i></div>
+						</div>
+					</div>
+					<div class="card">
+						<div class="content">
+							<div class="header">ShareX URL Shortener</div>
+						</div>
+<textarea class="image" readonly style="resize: none; border: none; font-family: monospace" rows=10>{
+  "Name": "{{config.name}} URLShortener",
+  "DestinationType": "URLShortener",
+  "RequestURL": "{{config.url}}upload",
+  "Arguments": {
+    "password": "SHITTYPASSWORDHERE",
+    "link": "$input$"
+  },
+  "URL": "$json:.url$",
+  "DeletionURL": "$json:.deleteUrl$"
+}</textarea>
+						<div class="extra content">
+							<div class="ui mini icon primary button" onclick="copyToClipboard($(this).prev().val())"><i class="copy outline icon"></i></div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/views/misc.hbs
+++ b/views/misc.hbs
@@ -5,7 +5,7 @@
 				{{> navigation }}
 			</div>
 			<div class="ui content center aligned">
-				<div class="ui input">
+				<div class="ui action input">
 					<input id="pas" placeholder="Password here" type="text">
 					<div class="ui positive button" onclick="$('textarea').each( function(){$(this).val($(this).text().replace('SHITTYPASSWORDHERE',$('#pas').val()));})">Set</div>
 					<div class="ui negative button" onclick="$('textarea').each(function(){$(this).val($(this).text());$('#pas').val('');})">Reset</div>

--- a/views/misc.hbs
+++ b/views/misc.hbs
@@ -7,7 +7,7 @@
 			<div class="ui content center aligned">
 				<div class="ui action input">
 					<input id="pas" placeholder="Password here" type="text">
-					<div class="ui positive button" onclick="$('textarea').each( function(){$(this).val($(this).text().replace('SHITTYPASSWORDHERE',$('#pas').val()));})">Set</div>
+					<div class="ui positive button" onclick="$('textarea').each(function(){$(this).val($(this).text().replace('SHITTYPASSWORDHERE',$('#pas').val()));})">Set</div>
 					<div class="ui negative button" onclick="$('textarea').each(function(){$(this).val($(this).text());$('#pas').val('');})">Reset</div>
 				</div>
 			</div>

--- a/views/partials/filters.hbs
+++ b/views/partials/filters.hbs
@@ -35,3 +35,39 @@
 		</div>
 	</div>
 </div>
+{{#section "filters"}}
+<script>
+	$(function() {
+
+		$("#rangestart").calendar({
+			type: "date",
+			endCalendar: $("#rangeend")
+		}).calendar("set date",urlParams.get('start'));
+
+		$("#rangeend").calendar({
+			type: "date",
+			startCalendar: $("#rangestart")
+		}).calendar("set date",urlParams.get('end'));
+
+		$("#filter-search").val(urlParams.get('search'));
+		$("#filter-search").keyup(function(event) {
+			if (event.keyCode === 13) {
+				$("#filter-submit").click();
+			}
+		});
+		
+		$("#filter-submit").click(function() {
+			const q = Qs.parse(location.search.replace(/^\?/, ""));
+			if ($("#rangestart").calendar("get date")) q.start = $("#rangestart").calendar("get date").toString();
+			if ($("#rangeend").calendar("get date")) q.end = $("#rangeend").calendar("get date").toString();
+			q.search = $("#filter-search").val();
+			location.search = Qs.stringify(q);
+		});
+
+		$("#filter-clear").click(function() {
+			location.search = "";
+		});
+
+	});
+</script>
+{{/section}}

--- a/views/partials/pagination.hbs
+++ b/views/partials/pagination.hbs
@@ -2,13 +2,13 @@
 	<b>{{addCommas paginationInfo.total_results}}</b> total results - <b>{{addCommas paginationInfo.total_pages}}</b> pages
 </p>
 <div class="ui buttons">
-	<a href="{{@root.route}}/{{paginationInfo.previous_page}}{{#if @root.query}}?{{@root.query}}{{/if}}" class="ui icon button {{#unless paginationInfo.has_previous_page}}disabled{{/unless}}">
+	<a href="{{@root.route}}/{{paginationInfo.previous_page}}{{#if @root.query}}?{{@root.query}}{{/if}}" class="ui icon button pageLeft {{#unless paginationInfo.has_previous_page}}disabled{{/unless}}">
 		<i class="left chevron icon"></i>
 	</a>
 	{{#each pages}}
 		<a href="{{@root.route}}/{{this}}{{#if @root.query}}?{{@root.query}}{{/if}}" class="ui button {{#is @root.paginationInfo.current_page this}}disabled{{/is}}">{{this}}</a>
 	{{/each}}
-	<a href="{{@root.route}}/{{paginationInfo.next_page}}{{#if @root.query}}?{{@root.query}}{{/if}}" class="ui right icon button {{#unless paginationInfo.has_next_page}}disabled{{/unless}}">
+	<a href="{{@root.route}}/{{paginationInfo.next_page}}{{#if @root.query}}?{{@root.query}}{{/if}}" class="ui right icon button pageRight {{#unless paginationInfo.has_next_page}}disabled{{/unless}}">
 		<i class="right chevron icon"></i>
 	</a>
 </div>

--- a/views/upload.hbs
+++ b/views/upload.hbs
@@ -13,9 +13,9 @@
 			</div>
 			<div class="ui content text">
 				<form class="ui basic form segment left aligned" action="{{pathname}}upload" method="post" enctype="multipart/form-data">
-					<div class="field">
+					<div class="field" id="Modefield">
 						<label for="mode">Choose upload type: </label>
-						<div class="ui selection dropdown" tabindex="0">
+						<div class="ui selection dropdown" id="modeSelect" tabindex="0">
 							<input name="mode" value="File" id="mode" type="hidden">
 							<i class="dropdown icon"></i>
 							<div class="text">File</div>
@@ -27,11 +27,11 @@
 						</div>
 					</div>
 					<div class="field" id="Filefield">
-						<label for="ffile">Choose, drop or paste file</label>
+						<label for="file">Choose, drop or paste file</label>
 						<div class="ui fluid file input action">
-							<input type="text" readonly placeholder="File">
-							<input type="file" id="ffile" name="file" autocomplete="off">
-							<div class="ui button">
+							<input type="text" id="fakefile" readonly placeholder="File">
+							<input style="display: none" type="file" id="file" name="file" autocomplete="off">
+							<div class="ui button" id="filebutton">
 								Select...
 							</div>
 						</div>
@@ -41,8 +41,8 @@
 						<input type="text" name="URL"  id="URL" placeholder="Fully qualified URL">
 					</div>
 					<div class="field" id="Namefield">
-						<label for="name">Custom filename (optional)</label>
-						<input type="text" name="name" id="name" placeholder="Custom filename (optional)">
+						<label for="filename">Custom filename (optional)</label>
+						<input type="text" name="filename" id="filename" placeholder="Custom filename (optional)">
 					</div>
 					<input type="hidden" name="online" value="yes">
 					<button id="SubmitButton" class="ui fluid primary button" type="submit">Submit</button>
@@ -56,9 +56,139 @@
 		</div>
 	</div>
 </div>
+{{#section "script"}}
+<script>
+	$(function() {
+	
+		$("#fakefile, #filebutton").on("click", function(e) {
+			$("#file").click();
+		});
 
-<style>
-	.ui.file.input input[type="file"] {
-		display: none;
-	}
-</style>
+		$("#file").on("change", function(e) {
+			var file = $(e.target);
+			var name = "";
+
+			for (var i=0; i<e.target.files.length; i++) {
+				name += e.target.files[i].name + ", ";
+			}
+
+			name = name.replace(/,\s*$/, "");
+
+			$("#fakefile").val(name);
+		});
+
+		$("#modeSelect").dropdown().dropdown({
+			onChange: function(value, text, selectedItem) {
+				let name = $("#filename").val();
+				$(".ui.basic.form")[0].reset();
+				$("#filename").val(name);
+				if (value == "Link") {
+					$('#Filefield').hide();
+					$('#URLfield').show();
+				}
+				else {
+					$('#Filefield').show();
+					$('#URLfield').hide();
+				};
+			}
+		});
+		
+		function errorMessage(err) {
+			$("body").html('<div class="ui middle aligned center aligned grid"><div class="column"><div class="ui centered green card"><div class="content"><h1 class="header" style="color: #DB2828 !important; font-size: 175%">Error</h1></div><p class="ui content text" id="error" style="font-size: 120%"></p><p class="ui content text" style="font-size: 120%"><button class="ui primary button" onClick="window.location.reload(true)" type="button">Go Back</button></p></div></div></div>');
+			$("#error").text(err);
+		}
+		
+		function successMessage(mess) {
+			$("body").html('<div class="ui middle aligned center aligned grid"><div class="column"><div class="ui centered green card"><div class="content"><h1 class="header" style="color: #229A33 !important; font-size: 175%">Success</h1></div><p class="ui content text" id="success" style="font-size: 120%"></p><p class="ui content text" style="font-size: 120%"><button  class="ui primary button" onClick="window.location.reload(true)" type="button">Go Back</button></p></div></div></div>');				$("#success").text(mess);
+		}
+		
+		function SubmitData(file) {
+			if (file == null && $('#mode').val() != "Link") return errorMessage("No file specified.");
+			$("#SubmitButton").addClass('loading').addClass('disabled');
+			var progress = $('#progress').show().progress().progress("set percent",0);
+			var formData = new FormData();
+			formData.append("name",$("#filename").val());
+			var urlQuery = "{{pathname}}upload";
+			if ($('#mode').val() != "Link") {
+				if ($('#mode').val() == "Paste") {
+					urlQuery = "{{pathname}}upload?"+$.param({ paste : 'true'});
+				}
+				formData.append("file",file);
+			}
+			else {
+				formData.append("link",$('#URL').val());
+			};
+			$.ajax({
+			url: urlQuery,
+			data: formData,
+			processData: false,
+			contentType: false,
+			type: 'POST',
+			xhr: function(){
+				var xhr = new window.XMLHttpRequest();
+				function HandlePrecent(evt) {if (evt.lengthComputable) { progress.progress("set percent",evt.loaded / evt.total * 100); } }
+				xhr.upload.addEventListener("progress", HandlePrecent, false);
+				xhr.addEventListener("progress", HandlePrecent, false);
+				return xhr;
+			},
+			success: function(result){
+				$(".ui.basic.form")[0].reset();
+				if (result.ok){
+					if ($('#mode').val() != "Link") {
+						window.location.href = result.url ;
+					}
+					else {
+						successMessage(result.url)
+					}
+				}
+				else {errorMessage(result.error)}
+			},
+			error: function(xhr, textStatus, errorThrown){
+				$(".ui.basic.form")[0].reset();
+				errorMessage("Error Uploading: " + errorThrown);
+			}
+			});
+
+		};
+
+		$("#SubmitButton").on("click", function(e) {
+			e.preventDefault();
+			e.stopPropagation();
+			SubmitData( $("#file")[0].files.item(0) );
+		});
+
+		$( document ).on('drag dragstart dragend dragover dragenter dragleave drop', function(e) {
+			e.preventDefault();
+			e.stopPropagation();
+		})
+		.on('dragover dragenter', function() {
+			if ($('#mode').val() == "Link") {
+				$('#modeSelect').dropdown("set selected","File");
+			}
+			$("#SubmitButton").removeClass('primary').addClass('secondary').html("Drop to upload");
+			$("#Modefield").addClass('disabled');
+			$('#Filefield').addClass('disabled');
+		})
+		.on('dragleave dragend', function() {
+			$("#SubmitButton").removeClass('secondary').addClass('primary').html("Submit");
+			$("#Modefield").removeClass('disabled');
+			$('#Filefield').removeClass('disabled');
+		})
+		.on('drop', function(e) {
+			$("#SubmitButton").removeClass('secondary').addClass('primary').html("Submit");
+			$("#fakefile").val("Droped File");
+			SubmitData(e.originalEvent.dataTransfer.files.item(0));
+		})
+		.on("paste", function(e){
+			var pastedData = e.originalEvent.clipboardData.items[0];
+			if ($('#mode').val() != "Link" && pastedData.kind === 'file') {
+				e.preventDefault();
+				e.stopPropagation();
+				$("#Modefield").addClass('disabled');
+				$("#fakefile").val("Pasted File");
+				SubmitData(pastedData.getAsFile());
+			}
+		});
+	});
+</script>
+{{/section}}

--- a/views/upload.hbs
+++ b/views/upload.hbs
@@ -8,6 +8,9 @@
 			<div class="ui content center aligned">
 				{{> navigation }}
 			</div>
+			<div class="ui content center aligned">
+				<a href="{{pathname}}misc" class="ui fluid basic button">ShareX Upload Configs</a>
+			</div>
 			<div class="ui content text">
 				<form class="ui basic form segment left aligned" action="{{pathname}}upload" method="post" enctype="multipart/form-data">
 					<div class="field">
@@ -42,7 +45,7 @@
 						<input type="text" name="name" id="name" placeholder="Custom filename (optional)">
 					</div>
 					<input type="hidden" name="online" value="yes">
-					<button class="ui fluid primary button" type="submit">Submit</button>
+					<button id="SubmitButton" class="ui fluid primary button" type="submit">Submit</button>
 					<div class="ui indicating progress" id="progress" style="margin-top: 1rem; display: none;">
 						<div class="bar">
 							<div class="progress"></div>


### PR DESCRIPTION
 - Adds /misc page that contains generated ShareX configuration snippets. User can enter password into site to set password in all of the configs or they can just change ``SHITTYPASSWORDHERE`` on their own.
Adds link to this page in /upload page.
Implements #16 
![obraz](https://user-images.githubusercontent.com/5893536/40441060-2d1dad22-5ec0-11e8-9590-d49c00ed309e.png)
![obraz](https://user-images.githubusercontent.com/5893536/40441074-354f7c64-5ec0-11e8-9234-148e0a1fd8c6.png)

 - Implements section helper to split scripts into templates that are related to them - decreases a bit size of each page. Cleaned up upload code some. This should be useful in future.